### PR TITLE
Agenda for Jan 2021 Meeting.

### DIFF
--- a/Meetings/2021-01-26.md
+++ b/Meetings/2021-01-26.md
@@ -1,0 +1,62 @@
+# PlanetaryPy TC Meeting 2021 January 26th @ 1:30 PM MST
+
+!!! Note, this is one week later than usual !!!
+
+* Zoom Link: https://cuboulder.zoom.us/j/2789149686
+
+## Participants
+
+* ?
+
+## Agenda
+
+### Outstanding action items from last time
+
+* MA: Complete pvl app by pushing changes to PR
+  - [PR 28](https://github.com/planetarypy/TC/pull/28) is now updated and needs only
+    one more approval before merge.
+* MA: Add more code to core package
+* AA/RB: Submit PR for adding SpiceyPy and Kalasiris as aff. package
+  - SpiceyPy application submitted and under review
+
+
+### Affiliated Package Review Guidelines update
+
+* [Updates PR](https://github.com/planetarypy/TC/pull/46) needs one more approval.
+* Time to update our Python requirement from 3.6 (End of Support: 2021-12-23) to 
+  3.7 (End of Support: 2023-06-27)?
+
+
+### pvl discussion
+
+* Github Actions now [merged](https://github.com/planetarypy/pvl/pull/76) for `pvl`.
+* The TravisCI Webhook can now be deactivated, but Ross doesn't have permissions.
+* [publish-to-test-pypi.yml runs too much?](https://github.com/planetarypy/pvl/issues/77)
+
+
+### SpiceyPy discussion
+
+* [SpiceyPy application submitted](https://github.com/planetarypy/TC/pull/44), and
+  under review (@rbeyer is coordinator).
+* External review solicited and provided.
+* Expect to publish combined review once the 
+  [Requirements Updates PR](https://github.com/planetarypy/TC/pull/46) is 
+  resolved.
+
+  
+### https://planetarypy.github.io/
+
+* Probably need to work on this next.
+* There was some outcry against Jekyll, but we're not doing anything complicated,
+  and Ross has updates (in offline local repo) that could be PRed soon.
+* Go with that, or try and invent something new?
+
+
+### Continue discussion on planetarypy core
+
+* More discussion.
+
+
+## Action Items
+
+* ?


### PR DESCRIPTION
Note that the proposed date is one week later than usual!  I've got a science team meeting all day on the 19th, so I'd appreciate moving us back one week (just this time).