### PR TITLE
Added CJT Udovicic per January 2024 TC vote.

### DIFF
--- a/Members.md
+++ b/Members.md
@@ -4,3 +4,4 @@
 * Ross Beyer
 * Andrew Annex
 * Chase Million
+* Christian J. Tai Udovicic


### PR DESCRIPTION
We voted on adding Christian at the January meeting, and it is long overdue to add him to this roster.